### PR TITLE
[ feat ] : #149 회원 정보 수정 페이지 수정, 회원 비밀번호 수정 페이지 추가, 탈퇴 페이지 수정

### DIFF
--- a/frontend/src/app/account/edit/page.tsx
+++ b/frontend/src/app/account/edit/page.tsx
@@ -8,12 +8,15 @@ import { useRouter } from 'next/navigation'
 export default function EditProfilePage() {
     const router = useRouter()
     const [formData, setFormData] = useState({
-        email: 'user@example.com', // 기존 이메일
-        phone: '010-1234-5678', // 기존 전화번호
-        nickname: '사용자', // 기존 닉네임
-        password: '',
-        newPassword: '',
-        confirmPassword: '',
+        email: 'test5@example.com',
+        phone: '010-5555-5678',
+        nickname: 'bookTree_5150289c',
+    })
+
+    const [editState, setEditState] = useState({
+        email: false,
+        phone: false,
+        nickname: false,
     })
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -24,14 +27,18 @@ export default function EditProfilePage() {
         }))
     }
 
-    const handleSubmit = (e: React.FormEvent) => {
-        e.preventDefault()
-        // TODO: 프로필 수정 로직 구현
-        console.log('프로필 수정:', formData)
+    const handleFieldChange = (field: string) => {
+        setEditState((prev) => ({
+            ...prev,
+            [field]: false,
+        }))
     }
 
-    const handleWithdraw = () => {
-        router.push('/account/withdraw')
+    const startEdit = (field: string) => {
+        setEditState((prev) => ({
+            ...prev,
+            [field]: true,
+        }))
     }
 
     return (
@@ -40,115 +47,132 @@ export default function EditProfilePage() {
                 <div className={styles.formContainer}>
                     <h1 className={styles.title}>회원정보 수정</h1>
 
-                    <form className={styles.form} onSubmit={handleSubmit}>
+                    <form className={styles.form}>
                         <div className={styles.inputGroup}>
                             <label htmlFor="email" className={styles.label}>
                                 이메일
                             </label>
-                            <input
-                                type="email"
-                                id="email"
-                                name="email"
-                                value={formData.email}
-                                onChange={handleChange}
-                                className={styles.input}
-                                placeholder="이메일을 입력하세요"
-                            />
+                            <div className={styles.inputWrapper}>
+                                <div className={styles.inputContainer}>
+                                    {editState.email ? (
+                                        <input
+                                            type="email"
+                                            id="email"
+                                            name="email"
+                                            value={formData.email}
+                                            onChange={handleChange}
+                                            className={styles.input}
+                                            placeholder="이메일을 입력하세요"
+                                        />
+                                    ) : (
+                                        <div className={styles.value}>{formData.email}</div>
+                                    )}
+                                </div>
+                                <button
+                                    type="button"
+                                    onClick={() => (editState.email ? handleFieldChange('email') : startEdit('email'))}
+                                    className={styles.changeButton}
+                                >
+                                    {editState.email ? '적용' : '변경'}
+                                </button>
+                            </div>
                         </div>
 
                         <div className={styles.inputGroup}>
                             <label htmlFor="phone" className={styles.label}>
                                 핸드폰 번호
                             </label>
-                            <input
-                                type="tel"
-                                id="phone"
-                                name="phone"
-                                value={formData.phone}
-                                onChange={handleChange}
-                                className={styles.input}
-                                placeholder="핸드폰 번호를 입력하세요"
-                            />
+                            <div className={styles.inputWrapper}>
+                                <div className={styles.inputContainer}>
+                                    {editState.phone ? (
+                                        <input
+                                            type="tel"
+                                            id="phone"
+                                            name="phone"
+                                            value={formData.phone}
+                                            onChange={handleChange}
+                                            className={styles.input}
+                                            placeholder="핸드폰 번호를 입력하세요"
+                                        />
+                                    ) : (
+                                        <div className={styles.value}>{formData.phone}</div>
+                                    )}
+                                </div>
+                                <button
+                                    type="button"
+                                    onClick={() => (editState.phone ? handleFieldChange('phone') : startEdit('phone'))}
+                                    className={styles.changeButton}
+                                >
+                                    {editState.phone ? '적용' : '변경'}
+                                </button>
+                            </div>
                         </div>
 
                         <div className={styles.inputGroup}>
                             <label htmlFor="nickname" className={styles.label}>
                                 닉네임
                             </label>
-                            <input
-                                type="text"
-                                id="nickname"
-                                name="nickname"
-                                value={formData.nickname}
-                                onChange={handleChange}
-                                className={styles.input}
-                                placeholder="닉네임을 입력하세요"
-                            />
-                        </div>
-
-                        <div className={styles.inputGroup}>
-                            <label htmlFor="password" className={styles.label}>
-                                현재 비밀번호
-                            </label>
-                            <input
-                                type="password"
-                                id="password"
-                                name="password"
-                                value={formData.password}
-                                onChange={handleChange}
-                                className={styles.input}
-                                placeholder="현재 비밀번호를 입력하세요"
-                            />
-                        </div>
-
-                        <div className={styles.inputGroup}>
-                            <label htmlFor="newPassword" className={styles.label}>
-                                새 비밀번호
-                            </label>
-                            <input
-                                type="password"
-                                id="newPassword"
-                                name="newPassword"
-                                value={formData.newPassword}
-                                onChange={handleChange}
-                                className={styles.input}
-                                placeholder="새 비밀번호를 입력하세요"
-                            />
-                        </div>
-
-                        <div className={styles.inputGroup}>
-                            <label htmlFor="confirmPassword" className={styles.label}>
-                                새 비밀번호 확인
-                            </label>
-                            <input
-                                type="password"
-                                id="confirmPassword"
-                                name="confirmPassword"
-                                value={formData.confirmPassword}
-                                onChange={handleChange}
-                                className={styles.input}
-                                placeholder="새 비밀번호를 다시 입력하세요"
-                            />
+                            <div className={styles.inputWrapper}>
+                                <div className={styles.inputContainer}>
+                                    {editState.nickname ? (
+                                        <input
+                                            type="text"
+                                            id="nickname"
+                                            name="nickname"
+                                            value={formData.nickname}
+                                            onChange={handleChange}
+                                            className={styles.input}
+                                            placeholder="닉네임을 입력하세요"
+                                        />
+                                    ) : (
+                                        <div className={styles.value}>{formData.nickname}</div>
+                                    )}
+                                </div>
+                                <button
+                                    type="button"
+                                    onClick={() =>
+                                        editState.nickname ? handleFieldChange('nickname') : startEdit('nickname')
+                                    }
+                                    className={styles.changeButton}
+                                >
+                                    {editState.nickname ? '적용' : '변경'}
+                                </button>
+                            </div>
                         </div>
 
                         <div className={styles.buttonContainer}>
-                            <button type="submit" className={styles.submitButton}>
-                                변경사항 저장
+                            <button
+                                type="button"
+                                onClick={() => router.push('/account/editPassword')}
+                                className={styles.editPasswordButton}
+                            >
+                                비밀번호 변경
                             </button>
-                            <button type="button" onClick={handleWithdraw} className={styles.withdrawButton}>
+                            <button
+                                type="button"
+                                onClick={() => router.push('/mypage')}
+                                className={styles.cancelButton}
+                            >
+                                취소
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => router.push('/account/withdraw')}
+                                className={styles.withdrawButton}
+                            >
                                 회원 탈퇴
                             </button>
                         </div>
                     </form>
                 </div>
             </div>
-
             <footer className={styles.footer}>
                 <div className={styles.footerDivider}></div>
                 <div className={styles.footerLine}></div>
-                <div className={styles.footerContent}></div>
-                <div className={styles.footerText}>
-                    <span className={styles.copyright}>© 2025 All rights reserved.</span>
+                <div className={styles.footerContent}>
+                    <div className={styles.footerText}>
+                        <span className={styles.copyright}>© 2024 BookTree. All rights reserved.</span>
+                    </div>
                 </div>
             </footer>
         </div>

--- a/frontend/src/app/account/editPassword/editPassword.module.css
+++ b/frontend/src/app/account/editPassword/editPassword.module.css
@@ -86,7 +86,7 @@
     background-color: #256d41;
 }
 
-.withdrawButton {
+.cancelButton {
     width: 100%;
     padding: 0.75rem 1.5rem;
     background-color: rgb(220 38 38);
@@ -99,7 +99,7 @@
     transition: all 0.2s;
 }
 
-.withdrawButton:hover {
+.cancelButton:hover {
     background-color: rgb(185 28 28);
     color: white;
 }
@@ -167,132 +167,4 @@
     .formContainer {
         padding: 2rem;
     }
-}
-
-.editPasswordButton {
-    width: 100%;
-    padding: 0.75rem 1.5rem;
-    background-color: #2e804e;
-    color: white;
-    border: none;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.editPasswordButton:hover {
-    background-color: #256d41;
-}
-
-.inputWrapper {
-    display: flex;
-    gap: 1rem;
-    align-items: flex-start;
-    width: 100%;
-}
-
-.inputContainer {
-    flex: 1;
-}
-
-.changeButton {
-    padding: 0.75rem 1.5rem;
-    background-color: #2e804e;
-    color: white;
-    border: none;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    height: 2.75rem;
-    transition: all 0.2s;
-    margin-top: 1.5rem;
-}
-
-.changeButton:hover {
-    background-color: #256d41;
-}
-
-.value {
-    padding: 0.75rem 0;
-    font-size: 0.875rem;
-    color: #374151;
-}
-
-.buttonContainer {
-    margin-top: 2rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    width: 100%;
-}
-
-.editPasswordButton {
-    width: 100%;
-    padding: 0.75rem 1.5rem;
-    background-color: #2e804e;
-    color: white;
-    border: none;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.editPasswordButton:hover {
-    background-color: #256d41;
-}
-
-.cancelButton {
-    width: 100%;
-    padding: 0.75rem 1.5rem;
-    background-color: #6b7280;
-    color: white;
-    border: none;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.cancelButton:hover {
-    background-color: #4b5563;
-}
-
-.withdrawButton {
-    width: 100%;
-    padding: 0.75rem 1.5rem;
-    background-color: rgb(220 38 38);
-    color: white;
-    border: none;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.withdrawButton:hover {
-    background-color: rgb(185 28 28);
-}
-
-.cancelButton {
-    width: 100%;
-    padding: 0.75rem 1.5rem;
-    background-color: #2e804e; /* 초록색으로 변경 */
-    color: white;
-    border: none;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.cancelButton:hover {
-    background-color: #256d41; /* hover 색상도 동일하게 변경 */
 }

--- a/frontend/src/app/account/editPassword/page.tsx
+++ b/frontend/src/app/account/editPassword/page.tsx
@@ -1,0 +1,90 @@
+'use client'
+import { useState } from 'react'
+import styles from './editPassword.module.css'
+import { useRouter } from 'next/navigation'
+
+export default function EditPassword() {
+    const router = useRouter()
+    const [passwords, setPasswords] = useState({
+        currentPassword: '',
+        newPassword: '',
+        confirmPassword: '',
+    })
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setPasswords({
+            ...passwords,
+            [e.target.name]: e.target.value,
+        })
+    }
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault()
+        // 비밀번호 변경 API 호출 로직 추가
+        // 성공시 edit 페이지로 리다이렉트
+        router.push('/account/edit')
+    }
+
+    return (
+        <div className={styles.container}>
+            <div className={styles.mainWrapper}>
+                <div className={styles.formContainer}>
+                    <h1 className={styles.title}>비밀번호 변경</h1>
+                    <form onSubmit={handleSubmit} className={styles.form}>
+                        <div className={styles.inputGroup}>
+                            <label className={styles.label}>현재 비밀번호</label>
+                            <input
+                                type="password"
+                                name="currentPassword"
+                                value={passwords.currentPassword}
+                                onChange={handleChange}
+                                className={styles.input}
+                            />
+                        </div>
+                        <div className={styles.inputGroup}>
+                            <label className={styles.label}>새 비밀번호</label>
+                            <input
+                                type="password"
+                                name="newPassword"
+                                value={passwords.newPassword}
+                                onChange={handleChange}
+                                className={styles.input}
+                            />
+                        </div>
+                        <div className={styles.inputGroup}>
+                            <label className={styles.label}>새 비밀번호 확인</label>
+                            <input
+                                type="password"
+                                name="confirmPassword"
+                                value={passwords.confirmPassword}
+                                onChange={handleChange}
+                                className={styles.input}
+                            />
+                        </div>
+                        <div className={styles.buttonContainer}>
+                            <button type="submit" className={styles.submitButton}>
+                                저장
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => router.push('/account/edit')}
+                                className={styles.cancelButton}
+                            >
+                                취소
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            <footer className={styles.footer}>
+                <div className={styles.footerDivider}></div>
+                <div className={styles.footerLine}></div>
+                <div className={styles.footerContent}>
+                    <div className={styles.footerText}>
+                        <span className={styles.copyright}>© 2024 BookTree. All rights reserved.</span>
+                    </div>
+                </div>
+            </footer>
+        </div>
+    )
+}

--- a/frontend/src/app/account/withdraw/page.tsx
+++ b/frontend/src/app/account/withdraw/page.tsx
@@ -1,86 +1,93 @@
-"use client";
+'use client'
 
-import { useState } from "react";
-import styles from "./withdraw.module.css";
-import Link from "next/link";
+import { useState } from 'react'
+import styles from './withdraw.module.css'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation' // useRouter import 추가
 
 export default function WithdrawalPage() {
-  const [isAgreed, setIsAgreed] = useState(false);
-  const userEmail = "minsu_kim";
+    const router = useRouter() // router 정의
+    const [isAgreed, setIsAgreed] = useState(false)
+    const userEmail = 'minsu_kim'
 
-  return (
-    <div className={styles.container}>
-      <div className={styles.mainWrapper}>
-        <div className={styles.formContainer}>
-          <div className={styles.formHeader}>
-            <h1 className={styles.title}>회원탈퇴</h1>
-            <p className={styles.email}>@{userEmail}</p>
-          </div>
+    return (
+        <div className={styles.container}>
+            <div className={styles.mainWrapper}>
+                <div className={styles.formContainer}>
+                    <div className={styles.formHeader}>
+                        <h1 className={styles.title}>회원탈퇴</h1>
+                        <p className={styles.email}>@{userEmail}</p>
+                    </div>
 
-          <form className={styles.form}>
-            <div>
-              <div className={styles.subtitle}>
-                <h2>회원탈퇴를 진행하시기 전에 아래내용을 확인해주세요.</h2>
-              </div>
-              <div className={styles.noticeList}>
-                <p>
-                  • 계정 삭제 시 모든 데이터가 영구적으로 삭제되며 복구가
-                  불가능합니다.
-                </p>
-                <p>• 작성하신 게시물, 댓글 등의 콘텐츠가 모두 삭제됩니다.</p>
-                <p>• 구매하신 이용권은 환불되지 않으며 즉시 소멸됩니다.</p>
-                <p>• 연동된 소셜 계정 정보도 함께 삭제됩니다.</p>
-              </div>
+                    <form className={styles.form}>
+                        <div>
+                            <div className={styles.subtitle}>
+                                <h2>회원탈퇴를 진행하시기 전에 아래내용을 확인해주세요.</h2>
+                            </div>
+                            <div className={styles.noticeList}>
+                                <p>• 계정 삭제 시 모든 데이터가 영구적으로 삭제되며 복구가 불가능합니다.</p>
+                                <p>• 작성하신 게시물, 댓글 등의 콘텐츠가 모두 삭제됩니다.</p>
+                                <p>• 구매하신 이용권은 환불되지 않으며 즉시 소멸됩니다.</p>
+                                <p>• 연동된 소셜 계정 정보도 함께 삭제됩니다.</p>
+                            </div>
 
-              <div className={styles.checkboxContainer}>
-                <input
-                  id="agree"
-                  name="agree"
-                  type="checkbox"
-                  className={styles.checkbox}
-                  checked={isAgreed}
-                  onChange={(e) => setIsAgreed(e.target.checked)}
-                />
-                <label htmlFor="agree" className={styles.checkboxLabel}>
-                  위 내용을 모두 확인하였으며, 이에 동의합니다.
-                </label>
-              </div>
+                            <div className={styles.checkboxContainer}>
+                                <input
+                                    id="agree"
+                                    name="agree"
+                                    type="checkbox"
+                                    className={styles.checkbox}
+                                    checked={isAgreed}
+                                    onChange={(e) => setIsAgreed(e.target.checked)}
+                                />
+                                <label htmlFor="agree" className={styles.checkboxLabel}>
+                                    위 내용을 모두 확인하였으며, 이에 동의합니다.
+                                </label>
+                            </div>
 
-              <div className={styles.passwordContainer}>
-                <div className="mb-2">
-                  <label htmlFor="password" className={styles.passwordLabel}>
-                    비밀번호 확인
-                  </label>
+                            <div className={styles.passwordContainer}>
+                                <div className="mb-2">
+                                    <label htmlFor="password" className={styles.passwordLabel}>
+                                        비밀번호 확인
+                                    </label>
+                                </div>
+                                <input
+                                    type="password"
+                                    id="password"
+                                    name="password"
+                                    className={styles.passwordInput}
+                                    placeholder="현재 비밀번호를 입력해주세요"
+                                />
+                            </div>
+
+                            <div className={styles.buttonContainer}>
+                                <button
+                                    type="button"
+                                    onClick={() => router.push('/')} // 메인 페이지로 이동
+                                    className={styles.withdrawButton}
+                                >
+                                    회원 탈퇴
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => router.push('/account/edit')} // edit 페이지로 이동
+                                    className={styles.cancelButton}
+                                >
+                                    취소
+                                </button>
+                            </div>
+                        </div>
+                    </form>
                 </div>
-                <input
-                  type="password"
-                  id="password"
-                  name="password"
-                  className={styles.passwordInput}
-                  placeholder="현재 비밀번호를 입력해주세요"
-                />
-              </div>
-
-              <div className={styles.buttonContainer}>
-                <button type="submit" className={styles.withdrawButton}>
-                  회원탈퇴
-                </button>
-                <button type="button" className={styles.cancelButton}>
-                  취소
-                </button>
-              </div>
             </div>
-          </form>
+            <footer className={styles.footer}>
+                <div className={styles.footerDivider}></div>
+                <div className={styles.footerLine}></div>
+                <div className={styles.footerContent}></div>
+                <div className={styles.footerText}>
+                    <span className={styles.copyright}>© 2025 All rights reserved.</span>
+                </div>
+            </footer>
         </div>
-      </div>
-      <footer className={styles.footer}>
-        <div className={styles.footerDivider}></div>
-        <div className={styles.footerLine}></div>
-        <div className={styles.footerContent}></div>
-        <div className={styles.footerText}>
-          <span className={styles.copyright}>© 2025 All rights reserved.</span>
-        </div>
-      </footer>
-    </div>
-  );
+    )
 }


### PR DESCRIPTION
회원 정보 수정 페이지에서 비밀번호 수정 페이지 따로 분리해서 작성
기존 수정 페이지에 이메일, 닉네임, 핸드폰 번호 설정들을 일일히 변경해서 즉시 적용된 값을 볼 수 있게 하는 버튼 생성
탈퇴 페이지에 탈퇴 버튼 누르면 메인 페이지로, 취소 버튼 누르면 회원 정보 수정 페이지로 이동하게 변경